### PR TITLE
Disable Material3

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ void main() {
   runApp(MaterialApp(
     debugShowCheckedModeBanner: false,
     routes: routes,
-    theme: ThemeData(brightness: Brightness.light),
+    theme: ThemeData(brightness: Brightness.light, useMaterial3: false),
     darkTheme: ThemeData(
       brightness: Brightness.dark,
       scaffoldBackgroundColor: Colors.black,

--- a/lib/screens/hwyd.dart
+++ b/lib/screens/hwyd.dart
@@ -48,8 +48,8 @@ class _HwydState extends State<Hwyd> {
   }
 
   Future<void> _launchPrivacyPolicyUrl() async {
-    Uri privacyPolicyUrl =
-        Uri.parse('https://github.com/omartoutounji/hwyd/wiki/Privacy-Policy');
+    Uri privacyPolicyUrl = Uri.parse(
+        'https://github.com/omartoutounji/hwyd/wiki/HWYD-Privacy-Policy');
     if (!await launchUrl(privacyPolicyUrl)) {
       throw Exception('Could not launch $privacyPolicyUrl');
     }


### PR DESCRIPTION
As of Flutter 3.6, material3 is enabled by default. I have my own theme configuration so disabled it.